### PR TITLE
arakoon_cluster_connect_master: fix timeout allocation

### DIFF
--- a/src/arakoon-cluster-node.c
+++ b/src/arakoon-cluster-node.c
@@ -104,8 +104,8 @@ arakoon_rc _arakoon_cluster_node_connect(ArakoonClusterNode *node,
 
         FUNCTION_ENTER(_arakoon_cluster_node_connect);
 
-        _arakoon_log_info("arakoon-cluster-node: connecting to %s",
-                node->name);
+        _arakoon_log_info("arakoon-cluster-node: connecting to %s, timeout %d",
+			  node->name, timeout ? *timeout : 0);
 
         if(node->fd >= 0) {
                 _arakoon_log_warning(


### PR DESCRIPTION
Addresses https://github.com/openvstorage/crakoon/issues/1

Instead of allocating the user-specified timeout for all calls (allowing earlier calls to use a larger / the full share of it to the disadvantage of subsequent calls), the timeout is split up between the calls.